### PR TITLE
fix: skip tls verify while working on Wheatley replacement

### DIFF
--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -104,6 +104,7 @@ module Lita
 
         def websocket_options
           options = { ping: 10 }
+          options[:tls] = { :verify_peer => false } # temporarily workaround ca issue while working on Wheatley's replacement
           options[:proxy] = { :origin => config.proxy } if config.proxy
           options
         end

--- a/lita-slack.gemspec
+++ b/lita-slack.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "eventmachine"
   spec.add_runtime_dependency "faraday"
-  spec.add_runtime_dependency "faye-websocket", ">= 0.8.0"
+  spec.add_runtime_dependency "faye-websocket", ">= 0.11.1"
   spec.add_runtime_dependency "lita", ">= 4.7.1"
   spec.add_runtime_dependency "multi_json"
 


### PR DESCRIPTION
- upgrade [faye-websocket](https://github.com/faye/faye-websocket-ruby/pull/129) for tls verify_peer
- set verify_peer to false to skip tls verify

https://outreach-io.atlassian.net/browse/DT-3634